### PR TITLE
Adds Cassandra Datastax driver integration tests

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -169,6 +169,19 @@
             <artifactId>dubbo</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cassandra</groupId>
+            <artifactId>cassandra-all</artifactId>
+            <version>2.1.13</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/agent/src/main/resources/pinpoint-real-env-lowoverhead-sample.config
+++ b/agent/src/main/resources/pinpoint-real-env-lowoverhead-sample.config
@@ -325,7 +325,6 @@ profiler.google.httpclient.enable=true
 profiler.google.httpclient.async=true
 # Maximum anonymous innerclass number.
 profiler.google.httpclient.async.innerclassname.max=3
-<<<<<<< HEAD
 
 ###########################################################
 # gson
@@ -341,5 +340,3 @@ profiler.json.jackson=false
 # json-lib
 ###########################################################
 profiler.json.jsonlib=false
-=======
->>>>>>> Add support for cassandra #789

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/cassandra/CassandraDatastaxITBase.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/cassandra/CassandraDatastaxITBase.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2016 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.cassandra;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Statement;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifier;
+import com.navercorp.pinpoint.bootstrap.plugin.test.PluginTestVerifierHolder;
+import com.navercorp.pinpoint.common.util.DefaultSqlParser;
+import com.navercorp.pinpoint.common.util.SqlParser;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.Iterator;
+
+import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.event;
+import static com.navercorp.pinpoint.bootstrap.plugin.test.Expectations.sql;
+
+/**
+ * @author HyunGil Jeong
+ */
+public abstract class CassandraDatastaxITBase {
+
+    // com.navercorp.pinpoint.plugin.cassandra.CassandraConstants
+    protected static final String CASSANDRA = "CASSANDRA";
+    protected static final String CASSANDRA_EXECUTE_QUERY = "CASSANDRA_EXECUTE_QUERY";
+
+    protected static final String TEST_KEYSPACE = "mykeyspace";
+    protected static final String TEST_TABLE = "mytable";
+    protected static final String TEST_COL_ID = "id";
+    protected static final String TEST_COL_VALUE = "value";
+
+    protected static final String CQL_CREATE_KEYSPACE = String.format(
+            "CREATE KEYSPACE %s WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };",
+            TEST_KEYSPACE);
+    protected static final String CQL_CREATE_TABLE = String.format(
+            "CREATE TABLE %s ( %s int PRIMARY KEY, %s text );",
+            TEST_TABLE, TEST_COL_ID, TEST_COL_VALUE);
+    protected static final String CQL_INSERT = String.format(
+            "INSERT INTO %s (%s, %s) VALUES (?, ?);",
+            TEST_TABLE, TEST_COL_ID, TEST_COL_VALUE);
+    // for normalized sql used for sql cache
+    protected static final SqlParser SQL_PARSER = new DefaultSqlParser();
+
+    protected static Cluster cluster;
+
+    // see cassandra/cassandra_${cassandraVersion}.yaml
+    protected static String HOST;
+    protected static int PORT;
+    protected static String CASSANDRA_ADDRESS;
+
+    public static void initializeCluster(String cassandraVersion) throws Exception {
+        CassandraTestHelper.init(cassandraVersion);
+        HOST = CassandraTestHelper.getHost();
+        PORT = CassandraTestHelper.getNativeTransportPort();
+        CASSANDRA_ADDRESS = HOST + ":" + PORT;
+        cluster = Cluster.builder().addContactPoint(HOST).withPort(PORT).withoutMetrics().build();
+        // Create KeySpace
+        Session emptySession = null;
+        try {
+            emptySession = cluster.connect();
+            emptySession.execute(CQL_CREATE_KEYSPACE);
+        } finally {
+            closeSession(emptySession);
+        }
+        // Create Table
+        Session myKeyspaceSession = null;
+        try {
+            myKeyspaceSession = cluster.connect(TEST_KEYSPACE);
+            myKeyspaceSession.execute(CQL_CREATE_TABLE);
+        } finally {
+            closeSession(myKeyspaceSession);
+        }
+    }
+
+    @Test
+    public void test() throws Exception {
+        final int testId = 99;
+        final String testValue = "testValue";
+
+        PluginTestVerifier verifier = PluginTestVerifierHolder.getInstance();
+
+        Session myKeyspaceSession = null;
+
+        try {
+            myKeyspaceSession = cluster.connect(TEST_KEYSPACE);
+
+            // ===============================================
+            // Insert Data (PreparedStatement, BoundStatement)
+            PreparedStatement preparedStatement = myKeyspaceSession.prepare(CQL_INSERT);
+            BoundStatement boundStatement = new BoundStatement(preparedStatement);
+            boundStatement.bind(testId, testValue);
+            myKeyspaceSession.execute(boundStatement);
+
+            verifier.printCache();
+            // Cluster#connect(String)
+            Class<?> clusterClass = Class.forName("com.datastax.driver.core.Cluster");
+            Method connect = clusterClass.getDeclaredMethod("connect", String.class);
+            verifier.verifyTrace(event(CASSANDRA, connect, null, CASSANDRA_ADDRESS, TEST_KEYSPACE));
+            // SessionManager#prepare(String) OR AbstractSession#prepare(String)
+            Class<?> sessionClass;
+            try {
+                sessionClass = Class.forName("com.datastax.driver.core.AbstractSession");
+            } catch (ClassNotFoundException e) {
+                sessionClass = Class.forName("com.datastax.driver.core.SessionManager");
+            }
+            Method prepare = sessionClass.getDeclaredMethod("prepare", String.class);
+            verifier.verifyTrace(event(CASSANDRA, prepare, null, CASSANDRA_ADDRESS, TEST_KEYSPACE, sql(CQL_INSERT, null)));
+            // SessionManager#execute(Statement) OR AbstractSession#execute(Statement)
+            Method execute = sessionClass.getDeclaredMethod("execute", Statement.class);
+            verifier.verifyTrace(event(CASSANDRA_EXECUTE_QUERY, execute, null, CASSANDRA_ADDRESS, TEST_KEYSPACE, sql(CQL_INSERT, null)));
+
+            // ====================
+            // Select Data (String)
+            final String cqlSelect = String.format("SELECT %s, %s FROM %s WHERE %s = %d",
+                    TEST_COL_ID, TEST_COL_VALUE, TEST_TABLE, TEST_COL_ID, testId);
+            verifySelect(myKeyspaceSession.execute(cqlSelect), testId, testValue);
+
+            verifier.printCache();
+            // SessionManager#execute(String) OR AbstractSession#execute(String)
+            execute = sessionClass.getDeclaredMethod("execute", String.class);
+            String normalizedSelectSql = SQL_PARSER.normalizedSql(cqlSelect).getNormalizedSql();
+            verifier.verifyTrace(event(CASSANDRA_EXECUTE_QUERY, execute, null, CASSANDRA_ADDRESS, TEST_KEYSPACE, sql(normalizedSelectSql, String.valueOf(testId))));
+
+            // ====================
+            // Delete Data (String)
+            final String cqlDelete = String.format("DELETE FROM %s.%s WHERE %s = ?", TEST_KEYSPACE, TEST_TABLE, TEST_COL_ID);
+            myKeyspaceSession.execute(cqlDelete, testId);
+
+            verifier.printCache();
+            // SessionManager#execute(String, Object[]) OR AbstractSession#execute(String, Object[])
+            execute = sessionClass.getDeclaredMethod("execute", String.class, Object[].class);
+            String normalizedDeleteSql = SQL_PARSER.normalizedSql(cqlDelete).getNormalizedSql();
+            verifier.verifyTrace(event(CASSANDRA_EXECUTE_QUERY, execute, null, CASSANDRA_ADDRESS, TEST_KEYSPACE, sql(normalizedDeleteSql, null)));
+        } finally {
+            closeSession(myKeyspaceSession);
+        }
+    }
+
+    private void verifySelect(ResultSet rs, int expectedTestId, String expectedTestValue) {
+        int resultCount = 0;
+        Iterator<Row> iter = rs.iterator();
+        while (iter.hasNext()) {
+            Row row = iter.next();
+            Assert.assertEquals(expectedTestId, row.getInt(0));
+            Assert.assertEquals(expectedTestValue, row.getString(1));
+            ++resultCount;
+        }
+        Assert.assertEquals(1, resultCount);
+    }
+
+    private static void closeSession(Session session) {
+        if (session != null) {
+            session.close();
+        }
+    }
+
+    public static void cleanUpCluster() {
+        if (cluster != null) {
+            cluster.close();
+        }
+    }
+
+}

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/cassandra/CassandraDatastax_2_0_x_IT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/cassandra/CassandraDatastax_2_0_x_IT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.cassandra;
+
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+/**
+ * @author HyunGil Jeong
+ */
+@RunWith(PinpointPluginTestSuite.class)
+@Dependency({
+        "com.datastax.cassandra:cassandra-driver-core:[2.0.12,2.0.max]",
+        "org.apache.cassandra:cassandra-all:2.0.17",
+        "com.google.guava:guava:17.0",
+        "org.codehaus.plexus:plexus-utils:3.0.22"})
+public class CassandraDatastax_2_0_x_IT extends CassandraDatastaxITBase {
+
+    private static final String CASSANDRA_VERSION = "2_0_x";
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        initializeCluster(CASSANDRA_VERSION);
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        cleanUpCluster();
+    }
+
+}

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/cassandra/CassandraDatastax_2_1_x_IT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/cassandra/CassandraDatastax_2_1_x_IT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.cassandra;
+
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+/**
+ * @author HyunGil Jeong
+ */
+@RunWith(PinpointPluginTestSuite.class)
+@Dependency({
+        "com.datastax.cassandra:cassandra-driver-core:[2.1.9,2.1.max]",
+        "org.apache.cassandra:cassandra-all:2.1.13",
+        "com.google.guava:guava:17.0",
+        "org.codehaus.plexus:plexus-utils:3.0.22"})
+public class CassandraDatastax_2_1_x_IT extends CassandraDatastaxITBase {
+
+    private static final String CASSANDRA_VERSION = "2_1_x";
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        initializeCluster(CASSANDRA_VERSION);
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        cleanUpCluster();
+    }
+
+}

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/cassandra/CassandraDatastax_2_2_x_IT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/cassandra/CassandraDatastax_2_2_x_IT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.cassandra;
+
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+/**
+ * @author HyunGil Jeong
+ */
+@RunWith(PinpointPluginTestSuite.class)
+@Dependency({
+        "com.datastax.cassandra:cassandra-driver-core:[2.2.0-rc3,2.2.max]",
+        "org.apache.cassandra:cassandra-all:2.1.13",
+        "com.google.guava:guava:17.0",
+        "org.codehaus.plexus:plexus-utils:3.0.22"})
+public class CassandraDatastax_2_2_x_IT extends CassandraDatastaxITBase {
+
+    private static final String CASSANDRA_VERSION = "2_2_x";
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        initializeCluster(CASSANDRA_VERSION);
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        cleanUpCluster();
+    }
+
+}

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/cassandra/CassandraDatastax_3_0_x_IT.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/cassandra/CassandraDatastax_3_0_x_IT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.cassandra;
+
+import com.navercorp.pinpoint.test.plugin.Dependency;
+import com.navercorp.pinpoint.test.plugin.PinpointPluginTestSuite;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+/**
+ * @author HyunGil Jeong
+ */
+@RunWith(PinpointPluginTestSuite.class)
+@Dependency({
+        "com.datastax.cassandra:cassandra-driver-core:[3.0.0,3.0.max]",
+        "org.apache.cassandra:cassandra-all:2.1.13",
+        "com.google.guava:guava:17.0",
+        "org.codehaus.plexus:plexus-utils:3.0.22"})
+public class CassandraDatastax_3_0_x_IT extends CassandraDatastaxITBase {
+
+    private static final String CASSANDRA_VERSION = "3_0_x";
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        initializeCluster(CASSANDRA_VERSION);
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        cleanUpCluster();
+    }
+
+}

--- a/agent/src/test/java/com/navercorp/pinpoint/plugin/cassandra/CassandraTestHelper.java
+++ b/agent/src/test/java/com/navercorp/pinpoint/plugin/cassandra/CassandraTestHelper.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2016 NAVER Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.navercorp.pinpoint.plugin.cassandra;
+
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.exceptions.ConfigurationException;
+import org.apache.cassandra.service.EmbeddedCassandraService;
+import org.codehaus.plexus.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author HyunGil Jeong
+ */
+public class CassandraTestHelper {
+
+    private static final String CASSANDRA_HOME = "target/test-classes/cassandra";
+
+    private CassandraTestHelper() {
+    }
+
+    public static void init(final String cassandraVersion) throws IOException, ConfigurationException {
+        final String cassandraStorageDir = String.format("%s/data_%s", CASSANDRA_HOME, cassandraVersion);
+        final String cassandraConfigFile = String.format("cassandra/cassandra_%s.yaml", cassandraVersion);
+        System.setProperty("cassandra.storagedir", cassandraStorageDir);
+        System.setProperty("cassandra.config", cassandraConfigFile);
+        prepareEnvironment();
+        EmbeddedCassandraService cassandra = new EmbeddedCassandraService();
+        cassandra.start();
+    }
+
+    public static String getHost() {
+        return DatabaseDescriptor.getListenAddress().getHostName();
+    }
+
+    public static int getNativeTransportPort() {
+        return DatabaseDescriptor.getNativeTransportPort();
+    }
+
+    private static void prepareEnvironment() throws IOException {
+        try {
+            cleanUpFiles();
+        } catch (IOException e) {
+            // ignore - just let the server start
+        }
+    }
+
+    private static void cleanUpFiles() throws IOException {
+        Set<String> fileLocations = new HashSet<String>();
+        for (String dataFileLocation : DatabaseDescriptor.getAllDataFileLocations()) {
+            fileLocations.add(dataFileLocation);
+        }
+        fileLocations.add(DatabaseDescriptor.getCommitLogLocation());
+        fileLocations.add(DatabaseDescriptor.getSavedCachesLocation());
+        for (String fileLocation : fileLocations) {
+            File location = new File(fileLocation);
+            if (location.exists() && location.isDirectory()) {
+                FileUtils.deleteDirectory(fileLocation);
+            }
+        }
+    }
+}

--- a/agent/src/test/resources/cassandra/cassandra_2_0_x.yaml
+++ b/agent/src/test/resources/cassandra/cassandra_2_0_x.yaml
@@ -1,0 +1,28 @@
+cluster_name: Test Cluster
+commitlog_sync: batch
+commitlog_sync_batch_window_in_ms: 1.0
+commitlog_segment_size_in_mb: 5
+partitioner: org.apache.cassandra.dht.ByteOrderedPartitioner
+listen_address: 127.0.0.1
+storage_port: 7010
+start_native_transport: true
+native_transport_port: 9042
+start_rpc: false
+rpc_port: 9170
+ssl_storage_port: 7011
+column_index_size_in_kb: 4
+seed_provider:
+    - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+      parameters:
+          - seeds: "127.0.0.1"
+endpoint_snitch: org.apache.cassandra.locator.SimpleSnitch
+dynamic_snitch: true
+request_scheduler: org.apache.cassandra.scheduler.RoundRobinScheduler
+request_scheduler_id: keyspace
+concurrent_compactors: 1
+compaction_throughput_mb_per_sec: 16
+auto_snapshot: false
+commitlog_directory: target/test-classes/cassandra/commitlog
+saved_caches_directory: target/test-classes/cassandra/saved_caches
+data_file_directories:
+    - target/test-classes/cassandra/data

--- a/agent/src/test/resources/cassandra/cassandra_2_1_x.yaml
+++ b/agent/src/test/resources/cassandra/cassandra_2_1_x.yaml
@@ -1,0 +1,26 @@
+cluster_name: Test Cluster
+memtable_allocation_type: offheap_objects
+commitlog_sync: batch
+commitlog_sync_batch_window_in_ms: 1.0
+commitlog_segment_size_in_mb: 5
+partitioner: org.apache.cassandra.dht.ByteOrderedPartitioner
+listen_address: 127.0.0.1
+storage_port: 7010
+start_native_transport: true
+native_transport_port: 9042
+start_rpc: false
+rpc_port: 9170
+ssl_storage_port: 7011
+column_index_size_in_kb: 4
+disk_access_mode: mmap
+seed_provider:
+    - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+      parameters:
+          - seeds: "127.0.0.1"
+endpoint_snitch: org.apache.cassandra.locator.SimpleSnitch
+dynamic_snitch: true
+request_scheduler: org.apache.cassandra.scheduler.RoundRobinScheduler
+request_scheduler_id: keyspace
+concurrent_compactors: 1
+compaction_throughput_mb_per_sec: 16
+auto_snapshot: false

--- a/agent/src/test/resources/cassandra/cassandra_2_2_x.yaml
+++ b/agent/src/test/resources/cassandra/cassandra_2_2_x.yaml
@@ -1,0 +1,26 @@
+cluster_name: Test Cluster
+memtable_allocation_type: offheap_objects
+commitlog_sync: batch
+commitlog_sync_batch_window_in_ms: 1.0
+commitlog_segment_size_in_mb: 5
+partitioner: org.apache.cassandra.dht.ByteOrderedPartitioner
+listen_address: 127.0.0.1
+storage_port: 7010
+start_native_transport: true
+native_transport_port: 9042
+start_rpc: false
+rpc_port: 9170
+ssl_storage_port: 7011
+column_index_size_in_kb: 4
+disk_access_mode: mmap
+seed_provider:
+    - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+      parameters:
+          - seeds: "127.0.0.1"
+endpoint_snitch: org.apache.cassandra.locator.SimpleSnitch
+dynamic_snitch: true
+request_scheduler: org.apache.cassandra.scheduler.RoundRobinScheduler
+request_scheduler_id: keyspace
+concurrent_compactors: 1
+compaction_throughput_mb_per_sec: 16
+auto_snapshot: false

--- a/agent/src/test/resources/cassandra/cassandra_3_0_x.yaml
+++ b/agent/src/test/resources/cassandra/cassandra_3_0_x.yaml
@@ -1,0 +1,26 @@
+cluster_name: Test Cluster
+memtable_allocation_type: offheap_objects
+commitlog_sync: batch
+commitlog_sync_batch_window_in_ms: 1.0
+commitlog_segment_size_in_mb: 5
+partitioner: org.apache.cassandra.dht.ByteOrderedPartitioner
+listen_address: 127.0.0.1
+storage_port: 7010
+start_native_transport: true
+native_transport_port: 9042
+start_rpc: false
+rpc_port: 9170
+ssl_storage_port: 7011
+column_index_size_in_kb: 4
+disk_access_mode: mmap
+seed_provider:
+    - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+      parameters:
+          - seeds: "127.0.0.1"
+endpoint_snitch: org.apache.cassandra.locator.SimpleSnitch
+dynamic_snitch: true
+request_scheduler: org.apache.cassandra.scheduler.RoundRobinScheduler
+request_scheduler_id: keyspace
+concurrent_compactors: 1
+compaction_throughput_mb_per_sec: 16
+auto_snapshot: false

--- a/plugins/cassandra/src/main/java/com/navercorp/pinpoint/plugin/cassandra/interceptor/CassandraDriverConnectInterceptor.java
+++ b/plugins/cassandra/src/main/java/com/navercorp/pinpoint/plugin/cassandra/interceptor/CassandraDriverConnectInterceptor.java
@@ -35,8 +35,6 @@ import com.navercorp.pinpoint.bootstrap.util.InterceptorUtils;
 import com.navercorp.pinpoint.plugin.cassandra.CassandraConstants;
 
 /**
- * must be used with ExecutionPolicy.ALWAYS
- * 
  * @author dawidmalina
  */
 @TargetMethod(name = "connect", paramTypes = { "java.lang.String" })
@@ -76,9 +74,11 @@ public class CassandraDriverConnectInterceptor extends SpanEventSimpleAroundInte
         List<String> hostList = new ArrayList<String>();
         if (target instanceof Cluster) {
             Cluster cluster = (Cluster) target;
-            Set<Host> hosts = cluster.getMetadata().getAllHosts();
+            final Set<Host> hosts = cluster.getMetadata().getAllHosts();
+            final int port = cluster.getConfiguration().getProtocolOptions().getPort();
             for (Host host : hosts) {
-                hostList.add(host.toString().replace("/", ""));
+                final String hostAddress = host.getAddress().getHostAddress() + ":" + port;
+                hostList.add(hostAddress);
             }
         }
         if (args == null) {


### PR DESCRIPTION
Cassandra Datastax driver needed an integration test. This uses Cassandra's `EmbeddedCassandraService` to fire up a local Cassandra instance for each integration test.

This also introduces 2 changes to the current Datastax plugin.
1. Bind variable tracing is removed. It's a bit risky to extract bind variables from a serialized statement. Bind variable extraction therefore needs further implementation.
2. `DatabaseInfo` extraction is changed a bit. Port information was lost as `com.datastax.driver.core.Host` used to have `InetAddress` instead of `InetSocketAddress` (until 2.0.2). This change is not a complete necessity since the affected version's pretty old. Please take a look at it and feel free to revert it back if the previous implementation was a better idea.
